### PR TITLE
Define feature macros only on Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,11 @@ NAME=termbox
 CC=gcc
 FLAGS=-std=c99 -pedantic -Wall -Werror -g
 
+OS:=$(shell uname -s)
+ifeq ($(OS),Linux)
+	FLAGS+=-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE
+endif
+
 BIND=bin
 SRCD=src
 OBJD=obj

--- a/src/term.c
+++ b/src/term.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
 #include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/termbox.c
+++ b/src/termbox.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
-#define _XOPEN_SOURCE
 #include "term.h"
 #include "termbox.h"
 #include "memstream.h"


### PR DESCRIPTION
This patch makes it working on BSD (tested on DragonFly BSD, should be
the same on FreeBSD).  Fix issue: https://github.com/nsf/termbox/issues/110

On Linux, such features macros (_POSIX_C_SOURCE, _XOPEN_SOURCE) are
required to expose more functions.  However, on *BSD, almost everything
is exposed when no feature macros are defined, while defining feature
macros would restrict the functions to be exposed.

See more information at:
https://lists.freebsd.org/pipermail/freebsd-standards/2004-March/000474.html