### PR TITLE
fix several `-Werror=unused-result`

### DIFF
--- a/src/memstream.c
+++ b/src/memstream.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -13,7 +14,7 @@ void memstream_init(struct memstream* s, int fd, void* buffer, size_t len)
 
 void memstream_flush(struct memstream* s)
 {
-	write(s->file, s->data, s->pos);
+	assert(write(s->file, s->data, s->pos) == s->pos);
 	s->pos = 0;
 }
 

--- a/src/termbox.c
+++ b/src/termbox.c
@@ -777,7 +777,7 @@ static void sigwinch_handler(int xxx)
 {
 	(void) xxx;
 	const int zzz = 1;
-	write(winch_fds[1], &zzz, sizeof(int));
+	assert(write(winch_fds[1], &zzz, sizeof(int)) == sizeof(int));
 }
 
 static void update_size(void)
@@ -876,7 +876,7 @@ static int wait_fill_event(struct tb_event* event, struct timeval* timeout)
 		{
 			event->type = TB_EVENT_RESIZE;
 			int zzz = 0;
-			read(winch_fds[0], &zzz, sizeof(int));
+			assert(read(winch_fds[0], &zzz, sizeof(int)) == sizeof(int));
 			buffer_size_change_request = 1;
 			get_term_size(&event->w, &event->h);
 			return TB_EVENT_RESIZE;


### PR DESCRIPTION
Prevents compilation when using `-Werror` on GCC 8.3.0

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>