### PR TITLE
Change ar to more generic command

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ $(OBJD)/%.o:%.c
 $(BIND)/$(NAME).a:$(OBJS)
 	@echo "compiling $@"
 	@mkdir -p $(BIND)
-	@ar rvs $(BIND)/$(NAME).a $(OBJS)
+	@$(AR) rvs $(BIND)/$(NAME).a $(OBJS)
 
 clean:
 	@echo "cleaning workspace"


### PR DESCRIPTION
This commit alters the makefile so `ar` can be set by build arguments instead of being hard-coded.